### PR TITLE
Add workshop versioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 * `git clone` the repository and `cd` into the root directory.
 * For the exercise Jupyter notebooks
   * create a virutual environment (recommended)  e.g. with [venv](https://docs.python.org/3/library/venv.html), [conda](https://docs.conda.io/en/latest/) or other.
-  
+
   * install python dependencies with `pip install -r requirements.txt` in a virtual environment,  Requires libglpk-dev for `fake_data_for_learning`.
 
 ## Workshop topics
@@ -44,3 +44,23 @@ In the exercise notebooks and `requirements.txt` you see which python packages I
 * [causality](https://github.com/akelleh/causality)
 * [dowhy](https://microsoft.github.io/dowhy/)
 * [pyro](https://pyro.ai/)
+
+## Releases
+
+I follow a semantic-versioning-like convention for releases of `<workshop-year>.<minor>.<patch>`. For now, the `minor` value will be an incrementing integer; as the module being developed in this repo is not planned to be pushed to [pypi](https://pypi.org/), I won't be very strict, and will likely keep `minor` at 0 even if the api changes. If it looks like I would ever give more than one workshop a year, the `minor` value could be used for the month of the workshop.
+
+### Process of creating a new workshop release
+
+If the release is for a new workshop year, then first manually change the version in the code-base to `<new-year>.0.0`. This release need not be a tagged release, as it is the same as the final release of the previous workshop in an earlier year.
+
+Once an initial release has been created for a new workshop, create subsequent tagged releases by using [bump2version](https://pypi.org/project/bump2version/).
+
+## Release history
+
+### v2020-02-uni-lj
+
+Created prior to the above versioning scheme, workshop at University of Ljublana in February, 2020.
+
+### v2022.0.1
+
+Add initial exercises and methods for Simpson's paradox.

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,5 @@ fake-data-for-learning
 
 pytest
 flake8
+
+bump2version

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 2022.0.0
+current_version = 2022.0.1
 commit = True
 tag = True
 
@@ -15,4 +15,3 @@ exclude = docs
 
 [aliases]
 test = pytest
-# Define setup.py command aliases here

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,15 +1,11 @@
 [bumpversion]
-current_version = 0.1.0
+current_version = 2022.0.0
 commit = True
 tag = True
 
 [bumpversion:file:setup.py]
 search = version='{current_version}'
 replace = version='{new_version}'
-
-[bumpversion:file:risk_learning/__init__.py]
-search = __version__ = '{current_version}'
-replace = __version__ = '{new_version}'
 
 [bdist_wheel]
 universal = 1

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ test_requirements = [
 
 setup(
     name='risk_learning',
-    version='2022.0.0',
+    version='2022.0.1',
     author="Paul Larsen",
     author_email='munichpavel@gmail.com',
     url='https://github.com/munichpavel/risk_learning',

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ test_requirements = [
 
 setup(
     name='risk_learning',
-    version='0.1.0',
+    version='2022.0.0',
     author="Paul Larsen",
     author_email='munichpavel@gmail.com',
     url='https://github.com/munichpavel/risk_learning',


### PR DESCRIPTION
Closes #6 

If the release is for a new workshop year, then first manually change the version in the code-base to `<new-year>.0.0`. This release need not be a tagged release, as it is the same as the final release of the previous workshop in an earlier year.

Once an initial release has been created for a new workshop, create subsequent tagged releases by using [bump2version](https://pypi.org/project/bump2version/).